### PR TITLE
Ensure cURL uses available system temp directory to store cookie files

### DIFF
--- a/src/ByHttpRequest/QueryResultFetcher.php
+++ b/src/ByHttpRequest/QueryResultFetcher.php
@@ -118,7 +118,7 @@ class QueryResultFetcher {
 	 */
 	public function doAuthenticateRemoteWiki( $credentials ) {
 
-		$cookiefile = 'seql_'.time();
+		$cookiefile = tempnam(sys_get_temp_dir(), 'seql_'.time());
 
 		$httpRequest = $this->httpRequestFactory->newCurlRequest();
 

--- a/src/ByHttpRequest/QueryResultFetcher.php
+++ b/src/ByHttpRequest/QueryResultFetcher.php
@@ -66,6 +66,7 @@ class QueryResultFetcher {
 	 * @param HttpRequestFactory $httpRequestFactory
 	 * @param QueryResultFactory $queryResultFactory
 	 * @param JsonResponseParser $jsonResponseParser
+	 * @param array|bool $credentials
 	 */
 	public function __construct( HttpRequestFactory $httpRequestFactory, QueryResultFactory $queryResultFactory, JsonResponseParser $jsonResponseParser, $credentials ) {
 		$this->httpRequestFactory = $httpRequestFactory;

--- a/src/ByHttpRequest/QueryResultFetcher.php
+++ b/src/ByHttpRequest/QueryResultFetcher.php
@@ -118,7 +118,7 @@ class QueryResultFetcher {
 	 */
 	public function doAuthenticateRemoteWiki( $credentials ) {
 
-		$cookiefile = tempnam(sys_get_temp_dir(), 'seql_'.time());
+		$cookiefile = tempnam(wfTempDir(), 'seql_'.time());
 
 		$httpRequest = $this->httpRequestFactory->newCurlRequest();
 


### PR DESCRIPTION
Uses `wfTempDir` to get temp directory